### PR TITLE
Fix race condition that occurs on device link authorisation.

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -194,6 +194,9 @@ public class ApplicationContext extends MultiDexApplication implements Dependenc
       if (userHexEncodedPublicKey != null) {
         if (TextSecurePreferences.getNeedsIsRevokedSlaveDeviceCheck(this)) {
           MultiDeviceUtilities.checkIsRevokedSlaveDevice(this);
+        } else {
+          // We always update our current device links onto the server in case we failed to do so upon linking
+          MultiDeviceUtilities.updateDeviceLinksOnServer(this);
         }
       }
     }

--- a/src/org/thoughtcrime/securesms/loki/MultiDeviceUtilities.kt
+++ b/src/org/thoughtcrime/securesms/loki/MultiDeviceUtilities.kt
@@ -42,6 +42,12 @@ fun checkIsRevokedSlaveDevice(context: Context) {
   }
 }
 
+fun updateDeviceLinksOnServer(context: Context) {
+  val hexEncodedPublicKey = TextSecurePreferences.getLocalNumber(context)
+  val deviceLinks = DatabaseFactory.getLokiAPIDatabase(context).getDeviceLinks(hexEncodedPublicKey)
+  LokiFileServerAPI.shared.setDeviceLinks(deviceLinks)
+}
+
 fun getAllDeviceFriendRequestStatuses(context: Context, hexEncodedPublicKey: String): Promise<Map<String, LokiThreadFriendRequestStatus>, Exception> {
   val lokiThreadDatabase = DatabaseFactory.getLokiThreadDatabase(context)
   return LokiDeviceLinkUtilities.getAllLinkedDeviceHexEncodedPublicKeys(hexEncodedPublicKey).map { keys ->

--- a/src/org/thoughtcrime/securesms/loki/redesign/activities/LandingActivity.kt
+++ b/src/org/thoughtcrime/securesms/loki/redesign/activities/LandingActivity.kt
@@ -114,7 +114,6 @@ class LandingActivity : BaseActionBarActivity(), LinkDeviceSlaveModeDialogDelega
     }
 
     override fun onDeviceLinkRequestAuthorized(deviceLink: DeviceLink) {
-        LokiFileServerAPI.shared.addDeviceLink(deviceLink)
         TextSecurePreferences.setMasterHexEncodedPublicKey(this, deviceLink.masterHexEncodedPublicKey)
         val intent = Intent(this, HomeActivity::class.java)
         show(intent)


### PR DESCRIPTION
Upon authorisation, we upload our mapping to the server.
At the same time we also get a contact sync message and send out background friend request messages.
There was a race condition between those 2 functions where to correctly establish multi-device communication, you need your mapping on the server so that the other party knows that it's a secondary device and not a regular user.

I also made it so we upload our device mapping on start up in the case where we failed to during pairing.