### PR TITLE
WIP: Exclude firebase core/analytics

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -80,6 +80,9 @@
             android:name="firebase_crashlytics_collection_enabled"
             android:value="false" />
         <meta-data
+            android:name="google_analytics_ssaid_collection_enabled"
+            android:value="false" />
+        <meta-data
             android:name="google_analytics_adid_collection_enabled"
             android:value="false" />
         <meta-data

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,11 @@ dependencies {
     implementation 'android.arch.lifecycle:extensions:1.1.1'
     implementation 'android.arch.lifecycle:common-java8:1.1.1'
 
-    implementation "com.google.firebase:firebase-messaging:$firebase_messaging_version"
+    implementation "com.google.firebase:firebase-messaging:$firebase_messaging_version" {
+           exclude group: 'com.google.firebase', module: 'firebase-core'
+           exclude group: 'com.google.firebase', module: 'firebase-analytics'
+           exclude group: 'com.google.firebase', module: 'firebase-measurement-connector'
+    }
 
     implementation 'com.google.android.exoplayer:exoplayer-core:2.9.1'
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.1'

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -30,31 +30,24 @@ import android.widget.Toast;
 import android.widget.VideoView;
 
 import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.LoadControl;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.extractor.ExtractorsFactory;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.ui.PlayerControlView;
 import com.google.android.exoplayer2.ui.PlayerView;
-import com.google.android.exoplayer2.ui.SimpleExoPlayerView;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 
-import network.loki.messenger.R;
 import org.thoughtcrime.securesms.attachments.AttachmentServer;
 import org.thoughtcrime.securesms.logging.Log;
 import org.thoughtcrime.securesms.mms.PartAuthority;
@@ -63,6 +56,8 @@ import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.video.exo.AttachmentDataSourceFactory;
 
 import java.io.IOException;
+
+import network.loki.messenger.R;
 
 public class VideoPlayer extends FrameLayout {
 


### PR DESCRIPTION
Ref #178 

Attempting to remove the 'tracker' warning from exodus. The trackers are all inactive (see Android Manifest) however classes are being called form somewhere from inside Firebase messaging (which we do use) which must include classes that involve firebase analytics.

Signal seem to have gotten around this by excluding certain modules from their build.gradle: https://github.com/signalapp/Signal-Android/blob/master/app/build.gradle

Solution discussed here: https://community.signalusers.org/t/gcm-will-be-removed-from-google/3888/41

I was not able to implement this solution as the config fails with it, and this error is meaningless to me: 

`Could not find method com.google.firebase:firebase-messaging:18.0.0() for arguments [build_5vvzfyp58zc8ppihqeadisrlo$_run_closure3$_closure23@4bc0ede9] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.`

Someone will have to take a deeper look. Cleaned up some stuff while poking around for mentions of analytics.

Also, are we using a super old version of FCM?
