### PR TITLE
Fix SMS Button Flash

### DIFF
--- a/src/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -2066,7 +2066,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } else if (!isSecureText && !isDefaultSms) {
       unblockButton.setVisibility(View.GONE);
       inputPanel.setVisibility(View.GONE);
-      makeDefaultSmsButton.setVisibility(View.VISIBLE);
+      makeDefaultSmsButton.setVisibility(View.GONE);
       registerButton.setVisibility(View.GONE);
     } else {
       inputPanel.setVisibility(View.VISIBLE);


### PR DESCRIPTION
### Description
Fixes a UI glitch where when switching to a conversation view, a button 'enabling sms' is visible while the conversation loads. This is only really visible for a fraction of a second, but once seen it can't be unseen.

With more work I could probably cut out a lot of the code that's being used here to speed up loading times, but it's clear there is a LOT that could be cleaned up in Conversation Activity. Probably doesnt make sense to start cutting it back when it all should be addressed when we rewrite ConversationActivity anyway. 

Tested on Moto Vision One
