### PR TITLE
Style All Mentions the Same

### DIFF
--- a/src/org/thoughtcrime/securesms/loki/utilities/MentionUtilities.kt
+++ b/src/org/thoughtcrime/securesms/loki/utilities/MentionUtilities.kt
@@ -55,7 +55,6 @@ object MentionUtilities {
         val userLinkedDeviceHexEncodedPublicKeys = DatabaseFactory.getLokiAPIDatabase(context).getDeviceLinks(userHexEncodedPublicKey).flatMap { listOf( it.masterHexEncodedPublicKey, it.slaveHexEncodedPublicKey ) }.toMutableSet()
         userLinkedDeviceHexEncodedPublicKeys.add(userHexEncodedPublicKey)
         for (mention in mentions) {
-            if (!userLinkedDeviceHexEncodedPublicKeys.contains(mention.second)) { continue }
             result.setSpan(ForegroundColorSpan(context.resources.getColorWithID(R.color.accent, context.theme)), mention.first.lower, mention.first.upper, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
             result.setSpan(StyleSpan(Typeface.BOLD), mention.first.lower, mention.first.upper, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }


### PR DESCRIPTION
Remove check which causes your own mentions to be styled differently from mentions to others, this brings Session Android in line with desktop and other messengers like Telegram which style all mentions the same (Except for mentions where we don't know the username)

![image](https://user-images.githubusercontent.com/27277414/85088795-4ab27e80-b224-11ea-91e8-b15b5e776a55.png)
