### PR TITLE
Add a Space After Inserting a Mention

### DIFF
--- a/src/org/thoughtcrime/securesms/conversation/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/conversation/ConversationActivity.java
@@ -438,7 +438,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
             mentionCandidateSelectionView.setOnMentionCandidateSelected( mentionCandidate -> {
               mentions.add(mentionCandidate);
               String oldText = composeText.getText().toString();
-              String newText = oldText.substring(0, currentMentionStartIndex) + "@" + mentionCandidate.getDisplayName();
+              String newText = oldText.substring(0, currentMentionStartIndex) + "@" + mentionCandidate.getDisplayName() + " ";
               composeText.setText(newText);
               composeText.setSelection(newText.length());
               currentMentionStartIndex = -1;


### PR DESCRIPTION
Add a blank space after a mention is rendered in the Session typing textbox, this prevents the mention being improperly rendered if a user puts text directly after their mention. Closes #165  

https://www.youtube.com/watch?v=e-ORhEE9VVg