### PR TITLE
Fix Link Previews

### DIFF
--- a/src/org/thoughtcrime/securesms/linkpreview/LinkPreviewRepository.java
+++ b/src/org/thoughtcrime/securesms/linkpreview/LinkPreviewRepository.java
@@ -63,7 +63,10 @@ public class LinkPreviewRepository implements InjectableType {
 
   public LinkPreviewRepository(@NonNull Context context) {
     this.client = new OkHttpClient.Builder()
-                                  .proxySelector(new ContentProxySelector())
+                                  //It seems like Signal's proxy has been banned by Youtube.
+                                  //Just comment this out to fix link previews.
+                                  //We will move this to onion routing in the future
+                                  //.proxySelector(new ContentProxySelector())
                                   .addNetworkInterceptor(new ContentProxySafetyInterceptor())
                                   .cache(null)
                                   .build();


### PR DESCRIPTION
It seems Signal's proxy has been banned by Youtube.
We will use onion routing to fix this issue totally in the future.