### PR TITLE
Fix Restoration From Seed

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -737,6 +737,7 @@
     <string name="MessageDisplayHelper_bad_encrypted_message">Bad encrypted message</string>
     <string name="MessageDisplayHelper_message_encrypted_for_non_existing_session">Message encrypted for non-existing session</string>
     <string name="MessageRecord_session_restore_sent">You have sent a session restoration request to %s</string>
+    <string name="MessageRecord_session_restore_done">Secure session reset done</string>
 
     <!-- MmsMessageRecord -->
     <string name="MmsMessageRecord_bad_encrypted_mms_message">Bad encrypted MMS message</string>

--- a/src/org/thoughtcrime/securesms/conversation/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/conversation/ConversationFragment.java
@@ -358,7 +358,7 @@ public class ConversationFragment extends Fragment
       if (messageRecord.isGroupAction() || messageRecord.isCallLog() ||
           messageRecord.isJoined() || messageRecord.isExpirationTimerUpdate() ||
           messageRecord.isEndSession() || messageRecord.isIdentityUpdate() ||
-          messageRecord.isIdentityVerified() || messageRecord.isIdentityDefault() || messageRecord.isLokiSessionRestoreSent())
+          messageRecord.isIdentityVerified() || messageRecord.isIdentityDefault() || messageRecord.isLokiSessionRestoreSent() || messageRecord.isLokiSessionRestoreDone())
       {
         actionMessage = true;
       }

--- a/src/org/thoughtcrime/securesms/conversation/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/conversation/ConversationUpdateItem.java
@@ -114,6 +114,7 @@ public class ConversationUpdateItem extends LinearLayout
     else if (messageRecord.isIdentityVerified() ||
              messageRecord.isIdentityDefault())        setIdentityVerifyUpdate(messageRecord);
     else if (messageRecord.isLokiSessionRestoreSent()) setTextMessageRecord(messageRecord);
+    else if (messageRecord.isLokiSessionRestoreDone()) setTextMessageRecord(messageRecord);
     else                                               throw new AssertionError("Neither group nor log nor joined.");
 
     if (batchSelected.contains(messageRecord)) setSelected(true);

--- a/src/org/thoughtcrime/securesms/database/MmsSmsColumns.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsColumns.java
@@ -84,6 +84,7 @@ public interface MmsSmsColumns {
 
     // Loki
     protected static final long ENCRYPTION_LOKI_SESSION_RESTORE_SENT_BIT = 0x01000000;
+    protected static final long ENCRYPTION_LOKI_SESSION_RESTORE_DONE_BIT = 0x00100000;
 
     public static boolean isDraftMessageType(long type) {
       return (type & BASE_TYPE_MASK) == BASE_DRAFT_TYPE;
@@ -235,6 +236,10 @@ public interface MmsSmsColumns {
 
     public static boolean isLokiSessionRestoreSentType(long type) {
       return (type & ENCRYPTION_LOKI_SESSION_RESTORE_SENT_BIT) != 0;
+    }
+
+    public static boolean isLokiSessionRestoreDoneType(long type) {
+      return (type & ENCRYPTION_LOKI_SESSION_RESTORE_DONE_BIT) != 0;
     }
 
     public static boolean isLegacyType(long type) {

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -255,6 +255,10 @@ public class SmsDatabase extends MessagingDatabase {
     updateTypeBitmask(id, Types.ENCRYPTION_MASK, Types.ENCRYPTION_LOKI_SESSION_RESTORE_SENT_BIT);
   }
 
+  public void markAsLokiSessionRestorationDone(long id) {
+    updateTypeBitmask(id, Types.ENCRYPTION_MASK, Types.ENCRYPTION_LOKI_SESSION_RESTORE_DONE_BIT);
+  }
+
   public void markAsLegacyVersion(long id) {
     updateTypeBitmask(id, Types.ENCRYPTION_MASK, Types.ENCRYPTION_REMOTE_LEGACY_BIT);
   }

--- a/src/org/thoughtcrime/securesms/database/model/DisplayRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/DisplayRecord.java
@@ -107,6 +107,8 @@ public abstract class DisplayRecord {
 
   public boolean isLokiSessionRestoreSent() { return SmsDatabase.Types.isLokiSessionRestoreSentType(type); }
 
+  public boolean isLokiSessionRestoreDone() { return SmsDatabase.Types.isLokiSessionRestoreDoneType(type); }
+
   public boolean isGroupUpdate() {
     return SmsDatabase.Types.isGroupUpdate(type);
   }

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -180,7 +180,7 @@ public abstract class MessageRecord extends DisplayRecord {
 
   public boolean isUpdate() {
     return isGroupAction() || isJoined() || isExpirationTimerUpdate() || isCallLog() ||
-           isEndSession()  || isIdentityUpdate() || isIdentityVerified() || isIdentityDefault() || isLokiSessionRestoreSent();
+           isEndSession()  || isIdentityUpdate() || isIdentityVerified() || isIdentityDefault() || isLokiSessionRestoreSent() || isLokiSessionRestoreDone();
   }
 
   public boolean isMediaPending() {

--- a/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
@@ -83,6 +83,8 @@ public class SmsMessageRecord extends MessageRecord {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
     } else if (isLokiSessionRestoreSent()) {
       return emphasisAdded(context.getString(R.string.SmsMessageRecord_secure_session_reset));
+    } else if (isLokiSessionRestoreDone()) {
+      return emphasisAdded(context.getString(R.string.MessageRecord_session_restore_done));
     } else if (isEndSession() && isOutgoing()) {
       return emphasisAdded(context.getString(R.string.SmsMessageRecord_secure_session_reset));
     } else if (isEndSession()) {

--- a/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
@@ -82,7 +82,7 @@ public class SmsMessageRecord extends MessageRecord {
     } else if (SmsDatabase.Types.isNoRemoteSessionType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
     } else if (isLokiSessionRestoreSent()) {
-      return emphasisAdded(context.getString(R.string.MessageRecord_session_restore_sent, recipient.toShortString()));
+      return emphasisAdded(context.getString(R.string.SmsMessageRecord_secure_session_reset));
     } else if (isEndSession() && isOutgoing()) {
       return emphasisAdded(context.getString(R.string.SmsMessageRecord_secure_session_reset));
     } else if (isEndSession()) {

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -84,6 +84,8 @@ public class ThreadRecord extends DisplayRecord {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
     } else if (isLokiSessionRestoreSent()) {
       return emphasisAdded(context.getString(R.string.SmsMessageRecord_secure_session_reset));
+    } else if (isLokiSessionRestoreDone()) {
+      return emphasisAdded(context.getString(R.string.MessageRecord_session_restore_done));
     } else if (SmsDatabase.Types.isEndSessionType(type)) {
       return emphasisAdded(context.getString(R.string.ThreadRecord_secure_session_reset));
     } else if (MmsSmsColumns.Types.isLegacyType(type)) {

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -83,7 +83,7 @@ public class ThreadRecord extends DisplayRecord {
     } else if (SmsDatabase.Types.isNoRemoteSessionType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_message_encrypted_for_non_existing_session));
     } else if (isLokiSessionRestoreSent()) {
-      return emphasisAdded(context.getString(R.string.MessageRecord_session_restore_sent, recipient.toShortString()));
+      return emphasisAdded(context.getString(R.string.SmsMessageRecord_secure_session_reset));
     } else if (SmsDatabase.Types.isEndSessionType(type)) {
       return emphasisAdded(context.getString(R.string.ThreadRecord_secure_session_reset));
     } else if (MmsSmsColumns.Types.isLegacyType(type)) {

--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -1072,36 +1072,38 @@ public class PushDecryptJob extends BaseJob implements InjectableType {
                                     @NonNull Optional<Long> smsMessageId)
   {
     SmsDatabase smsDatabase = DatabaseFactory.getSmsDatabase(context);
+    if (SessionMetaProtocol.shouldErrorMessageShow(context, timestamp)) {
+      if (!smsMessageId.isPresent()) {
+        Optional<InsertResult> insertResult = insertPlaceholder(sender, senderDevice, timestamp);
 
-    if (!smsMessageId.isPresent()) {
-      Optional<InsertResult> insertResult = insertPlaceholder(sender, senderDevice, timestamp);
-
-      if (insertResult.isPresent()) {
-        smsDatabase.markAsDecryptFailed(insertResult.get().getMessageId());
-        messageNotifier.updateNotification(context, insertResult.get().getThreadId());
+        if (insertResult.isPresent()) {
+          smsDatabase.markAsDecryptFailed(insertResult.get().getMessageId());
+          messageNotifier.updateNotification(context, insertResult.get().getThreadId());
+        }
+      } else {
+        smsDatabase.markAsDecryptFailed(smsMessageId.get());
       }
-    } else {
-      smsDatabase.markAsDecryptFailed(smsMessageId.get());
     }
-    SessionManagementProtocol.triggerSessionRestorationUI(context, sender);
+    SessionManagementProtocol.triggerSessionRestorationUI(context, sender, timestamp);
   }
 
   private void handleNoSessionMessage(@NonNull String sender, int senderDevice, long timestamp,
                                       @NonNull Optional<Long> smsMessageId)
   {
     SmsDatabase smsDatabase = DatabaseFactory.getSmsDatabase(context);
+    if (SessionMetaProtocol.shouldErrorMessageShow(context, timestamp)) {
+      if (!smsMessageId.isPresent()) {
+        Optional<InsertResult> insertResult = insertPlaceholder(sender, senderDevice, timestamp);
 
-    if (!smsMessageId.isPresent()) {
-      Optional<InsertResult> insertResult = insertPlaceholder(sender, senderDevice, timestamp);
-
-      if (insertResult.isPresent()) {
-        smsDatabase.markAsNoSession(insertResult.get().getMessageId());
-        messageNotifier.updateNotification(context, insertResult.get().getThreadId());
+        if (insertResult.isPresent()) {
+          smsDatabase.markAsNoSession(insertResult.get().getMessageId());
+          messageNotifier.updateNotification(context, insertResult.get().getThreadId());
+        }
+      } else {
+        smsDatabase.markAsNoSession(smsMessageId.get());
       }
-    } else {
-      smsDatabase.markAsNoSession(smsMessageId.get());
     }
-    SessionManagementProtocol.triggerSessionRestorationUI(context, sender);
+    SessionManagementProtocol.triggerSessionRestorationUI(context, sender, timestamp);
   }
 
   private void handleLegacyMessage(@NonNull String sender, int senderDevice, long timestamp,

--- a/src/org/thoughtcrime/securesms/loki/database/LokiAPIDatabase.kt
+++ b/src/org/thoughtcrime/securesms/loki/database/LokiAPIDatabase.kt
@@ -307,7 +307,7 @@ class LokiAPIDatabase(context: Context, helper: SQLCipherOpenHelper) : Database(
     override fun getSessionRequestSentTimestamp(publicKey: String): Long? {
         val database = databaseHelper.readableDatabase
         return database.get(sessionRequestSentTimestampTable, "${LokiAPIDatabase.publicKey} = ?", wrap(publicKey)) { cursor ->
-            cursor.getInt(LokiAPIDatabase.timestamp)
+            cursor.getLong(LokiAPIDatabase.timestamp)
         }?.toLong()
     }
 

--- a/src/org/thoughtcrime/securesms/loki/protocol/SessionMetaProtocol.kt
+++ b/src/org/thoughtcrime/securesms/loki/protocol/SessionMetaProtocol.kt
@@ -31,6 +31,12 @@ object SessionMetaProtocol {
     }
 
     @JvmStatic
+    fun shouldErrorMessageShow(context: Context, timestamp: Long): Boolean {
+        val restorationTimestamp = TextSecurePreferences.getRestorationTime(context)
+        return timestamp > restorationTimestamp
+    }
+
+    @JvmStatic
     fun handleProfileUpdateIfNeeded(context: Context, content: SignalServiceContent) {
         val rawDisplayName = content.senderDisplayName.orNull() ?: return
         if (rawDisplayName.isBlank()) { return }


### PR DESCRIPTION
It seems like Android has no way to force a thread without a real message to show in HomeActivity. 
But it behaves the same as Desktop. 
iOS can show the thread without any messages after restoration. 