### PR TITLE
Fix MediaSendActivity Crash

### DIFF
--- a/res/layout/emoji_variation_selector.xml
+++ b/res/layout/emoji_variation_selector.xml
@@ -4,6 +4,6 @@
     android:orientation="horizontal"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:background="?attr/emoji_variation_selector_background">
+    android:elevation="4dp">
 
 </LinearLayout>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -27,6 +27,25 @@
         <item name="colorAccent">@color/accent</item>
         <item name="actionModeBackground">@color/compose_view_background</item>
         <item name="windowActionModeOverlay">true</item>
+
+        <item name="emoji_tab_strip_background">@color/compose_view_background</item>
+        <item name="emoji_tab_indicator">@color/accent</item>
+        <item name="emoji_tab_underline">@color/gray78</item>
+        <item name="emoji_tab_seperator">@color/gray70</item>
+        <item name="emoji_drawer_background">@color/compose_text_view_background</item>
+        <item name="emoji_text_color">@color/white</item>
+
+        <item name="emoji_category_recent">@drawable/ic_recent_dark_20</item>
+        <item name="emoji_category_people">@drawable/ic_emoji_people_dark_20</item>
+        <item name="emoji_category_nature">@drawable/ic_emoji_animal_dark_20</item>
+        <item name="emoji_category_foods">@drawable/ic_emoji_food_dark_20</item>
+        <item name="emoji_category_activity">@drawable/ic_emoji_activity_dark_20</item>
+        <item name="emoji_category_places">@drawable/ic_emoji_travel_dark_20</item>
+        <item name="emoji_category_objects">@drawable/ic_emoji_object_dark_20</item>
+        <item name="emoji_category_symbol">@drawable/ic_emoji_symbol_dark_20</item>
+        <item name="emoji_category_flags">@drawable/ic_emoji_flag_dark_20</item>
+        <item name="emoji_category_emoticons">@drawable/ic_emoji_emoticon_dark_20</item>
+        <item name="emoji_variation_selector_background">@drawable/emoji_variation_selector_background_dark</item>
     </style>
 
     <style name="Session.DarkTheme.SubtitleActionBar" parent="@style/Theme.AppCompat">

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiVariationSelectorPopup.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiVariationSelectorPopup.java
@@ -1,17 +1,18 @@
 package org.thoughtcrime.securesms.components.emoji;
 
 import android.content.Context;
-import android.os.Build;
-import androidx.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.PopupWindow;
 
-import network.loki.messenger.R;
+import androidx.annotation.NonNull;
+
 import org.thoughtcrime.securesms.components.emoji.EmojiKeyboardProvider.EmojiEventListener;
 
 import java.util.List;
+
+import network.loki.messenger.R;
 
 public class EmojiVariationSelectorPopup extends PopupWindow {
 
@@ -29,10 +30,6 @@ public class EmojiVariationSelectorPopup extends PopupWindow {
 
     setBackgroundDrawable(null);
     setOutsideTouchable(true);
-
-    if (Build.VERSION.SDK_INT >= 21) {
-      setElevation(20);
-    }
   }
 
   public void setVariations(List<String> variations) {

--- a/src/org/thoughtcrime/securesms/util/ResUtil.java
+++ b/src/org/thoughtcrime/securesms/util/ResUtil.java
@@ -18,6 +18,7 @@
 package org.thoughtcrime.securesms.util;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.content.res.Resources.Theme;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
@@ -25,10 +26,14 @@ import androidx.annotation.ArrayRes;
 import androidx.annotation.AttrRes;
 import androidx.annotation.DimenRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import android.util.TypedValue;
 
+import org.thoughtcrime.securesms.logging.Log;
+
 public class ResUtil {
+  private static final String TAG = ResUtil.class.getSimpleName();
 
   public static int getColor(Context context, @AttrRes int attr) {
     final TypedArray styledAttributes = context.obtainStyledAttributes(new int[]{attr});
@@ -47,8 +52,15 @@ public class ResUtil {
     return out.resourceId;
   }
 
+  @Nullable
   public static Drawable getDrawable(Context c, @AttrRes int attr) {
-    return ContextCompat.getDrawable(c, getDrawableRes(c, attr));
+    int drawableRes = getDrawableRes(c, attr);
+    if (drawableRes == 0) {
+      Log.e(TAG, "Cannot find a drawable resource associated with the attribute: " + attr,
+              new Resources.NotFoundException());
+      return null;
+    }
+    return ContextCompat.getDrawable(c, drawableRes);
   }
 
   public static int[] getResourceIds(Context c, @ArrayRes int array) {


### PR DESCRIPTION
Fixes https://trello.com/c/4aLvnJu5/125-crash-on-pressing-the-emoji-button-on-mediasendactivity

The issue is related to the missing attributes in the used theme. This is a temporary patch as I'm currently refactoring themes somewhere else.